### PR TITLE
Account activation redirect mypage

### DIFF
--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -5,7 +5,7 @@ class AccountActivationsController < ApplicationController
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
       log_in user
-      flash[:success] = "Account activated!"
+      flash[:success] = "アカウントを有効化しました"
       redirect_to user
     else
       flash[:danger] = "Invalid activation link"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
         log_in user
         params[:session][:remember_me] == '1' ? remember(user) : forget(user)
         flash[:success] = "ログインに成功しました。"
-        redirect_to root_url
+        redirect_to user
       else
         message  = "アカウントが有効化されていません。 "
         message += "Eメールのアカウント有効化リンクをクリックしてください。"


### PR DESCRIPTION
## やったこと
アカウント有効化後、ログイン後にマイページへリダイレクトするようにした。
## やらないこと
無し
## できるようになること（ユーザ目線）
わざわざクリックしなくても自動的にマイページで設定が行える
## できなくなること（ユーザ目線）
最初のログイン後マイページ以外にはアクセスできなくなる
## 動作確認
ブラウザで確認、結果は成功
## その他
無し