### PR TITLE
itemの投稿ページのデザインを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'font-awesome-rails', '~> 4.7', '>= 4.7.0.5'
 # gem 'image_processing', '~> 1.2'
 gem 'payjp'
 gem 'dotenv-rails'
+gem 'marked-rails'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    marked-rails (0.3.2.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -323,6 +324,7 @@ DEPENDENCIES
   kaminari (~> 1.2, >= 1.2.1)
   letter_opener
   listen (~> 3.2)
+  marked-rails
   mysql2 (>= 0.4.4)
   payjp
   puma (~> 4.1)

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -5,6 +5,9 @@
 a {
   text-decoration: none;
 }
+body {
+  margin: 0;
+}
 // TOPページ
 //header
 .uk-border-rounded {
@@ -17,7 +20,20 @@ a {
   background-color: white;
 }
 
-//新規登録
+//新規登録フォーム
+.uk-width-form {
+  width: 30%;
+}
+.uk-margin-btn {
+  margin-bottom: 0;
+}
+
+//新規投稿ページ
+#markdown_preview {
+  border: 1px solid #e5e5e5;
+  background-color: #fff;
+  margin-left: 10px;
+}
 
 // 投稿一覧ページ
 
@@ -25,6 +41,8 @@ a {
 footer {
   background-color: #3e3e3e;
   color: whitesmoke;
+  margin-top: 3em;
+  height: 100%;
   ul {
     margin-top: 0;
     li {

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,18 +1,25 @@
 .uk-form
   %fieldset{"data-uk-margin" => ""}
-    %legend 出品ページ
     = form_with(model: @item, local: true) do |f|
-      .uk-form-row
-        = f.label :タイトル
-        = f.text_field :title, placeholder: "タイトルを入力"
-      .uk-form-row
-        = f.file_field :image
-      .uk-form-row
-        = f.label :内容　
-        = f.text_area :content, cols: 40, rows: 10, placeholder: "内容を入力"
-      .uk-form-row
-        = f.label :価格
-        = f.text_field :price, placeholder: "価格を入力"
-      .uk-form-row
-        = f.select :region, [["--", 0],["東京", 1],["三重", 2],["静岡",3],["愛知",4]]
-      = f.submit "出品する", disable_with: '出品中...', class: "uk-button"
+      .uk-margin
+        = f.text_field :title, placeholder: "タイトルを入力", class: 'uk-input'
+        .uk-flex.uk-margin
+          -# .uk-form-row
+          -#   = f.file_field :image
+          .uk-form.uk-width-2-1
+            = f.text_area :content, placeholder: "内容を入力",id: "markdown_editor_textarea", class: 'uk-textarea', size: "94x20"
+          .uk-width-2-1#markdown_preview
+          -# .uk-form-row
+          -#   = f.text_field :price, placeholder: "価格を入力"
+          -# .uk-form-row
+          -#   = f.select :region, [["--", 0],["東京", 1],["三重", 2],["静岡",3],["愛知",4]]
+        = f.submit "出品する", disable_with: '出品中...', class: "uk-button"
+
+:javascript
+  $(function () {
+
+    $('#markdown_editor_textarea').keyup(function () {
+      var html = marked($(this).val());
+      $('#markdown_preview').html(html);
+    });
+  });

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,10 @@
     = csp_meta_tag
     / UIkit CSS
     %link{:href => "https://cdn.jsdelivr.net/npm/uikit@3.5.4/dist/css/uikit.min.css", :rel => "stylesheet"}/
+    / Marked.js
+    %script{:src => "https://cdn.jsdelivr.net/npm/marked/marked.min.js"}
+    / jQuery
+    %script{:src => "https://code.jquery.com/jquery-3.0.0.min.js"}
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body.uk-background-muted
@@ -76,7 +80,6 @@
 
     = debug(params) if Rails.env.development?
     / UIkit JS
-    %script{:src => "https://code.jquery.com/jquery-3.0.0.min.js"}
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     %script{:src => "https://cdn.jsdelivr.net/npm/uikit@3.5.4/dist/js/uikit.min.js"}
     %script{:src => "https://cdn.jsdelivr.net/npm/uikit@3.5.4/dist/js/uikit-icons.min.js"}


### PR DESCRIPTION
close #54

## やったこと
投稿ページのviewを作成
マークダウン記法とリアルタイムプレビュー機能を導入
## やらないこと
マークダウン記法のヘルプアイコンの設置
## できるようになること（ユーザ目線）
マークダウン記法でプレビューを見ながら投稿作成できる
## できなくなること（ユーザ目線）
なし
## 動作確認
ブラウザで確認、結果は良好