### PR TITLE
[ADD] 投稿ページのリアルタイムプレビューでシンタックスハイライト機能を追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -33,6 +33,22 @@ body {
   border: 1px solid #e5e5e5;
   background-color: #fff;
   margin-left: 10px;
+  p{
+    margin-left: 20px;
+  }
+  h1,h2,h3{
+    border: 1px solid #f4f8fa;
+    background: #f4f8fa;
+    padding: 10px 20px;
+    border-radius: 4px;
+    margin-top: 20px
+  }
+  h4,h5,h6{
+    margin: 10px 20px;
+    padding-bottom: .3em;
+    border-bottom: 1px solid #eaecef;
+    position: relative;
+  }
 }
 
 // 投稿一覧ページ

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,6 +17,16 @@
 
 :javascript
   $(function () {
+    marked.setOptions({
+      //改行をそのまま反映
+      breaks : true,
+      //codeタグ使用時にデフォルトでつくlangage- を削除
+      langPrefix: '',
+      //syntax highlight を追加
+      highlight: function (code, lang) {
+        return hljs.highlightAuto(code, [lang]).value
+      }
+    });
 
     $('#markdown_editor_textarea').keyup(function () {
       var html = marked($(this).val());

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,8 @@
     = csp_meta_tag
     / UIkit CSS
     %link{:href => "https://cdn.jsdelivr.net/npm/uikit@3.5.4/dist/css/uikit.min.css", :rel => "stylesheet"}/
+    // syntax highlight
+    %link{:href => "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.1.2/build/styles/github.min.css", :rel => "stylesheet"}/
     / Marked.js
     %script{:src => "https://cdn.jsdelivr.net/npm/marked/marked.min.js"}
     / jQuery
@@ -80,6 +82,8 @@
 
     = debug(params) if Rails.env.development?
     / UIkit JS
+    // syntax highlight
+    %script{:src => "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.1.2/build/highlight.min.js"}
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     %script{:src => "https://cdn.jsdelivr.net/npm/uikit@3.5.4/dist/js/uikit.min.js"}
     %script{:src => "https://cdn.jsdelivr.net/npm/uikit@3.5.4/dist/js/uikit-icons.min.js"}


### PR DESCRIPTION
## やったこと
マークダウンのh1~h6タグに装飾を追加
codeタグ使用時にシンタックスハイライトされるようにした。
## やらないこと
新規投稿ページのデザイン
## できるようになること（ユーザ目線）
コードが見やすくなる。
## 動作確認
ブラウザで確認、結果はOK