### PR TITLE
[ADD] DMの削除機能を追加、DMページのデザインを作成、メッセージを降順で表示

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -22,11 +22,12 @@ body {
   margin: 0;
   letter-spacing: .01em;
   word-break: break-all;
-  font-family:"AvenirNext",
-              "Lato",
-              "Hirago KakuGothic ProN",
-              Meiryo,
-              sans-serif;
+  font-family:Ropa Sans,
+            -apple-system,
+            Helvetica Neue,
+            Arial,
+            hiragino kaku gothic pron,
+            sans-serif;
   font-size: .85rem;
   color: rgb(51, 51, 51);
 }
@@ -212,14 +213,14 @@ body {
     font-family: FontAwesome;
     content: "\f044";
     color: #666;
-   }
-   .fa-trash::before {
+  }
+  .fa-trash::before {
     font-family: FontAwesome;
     content: "\f1f8";
     color: #666;
-   }
-   a {
-     color: #666;
+  }
+  a {
+    color: #666;
    }
 }
 .post_user_box {
@@ -366,6 +367,29 @@ body {
   font-size: .9rem;
   text-align: center;
   padding: 2px 0 0 0;
+}
+//DMルーム
+.dm-room_title {
+  margin-top: 30px;
+  h2 {
+    font-size: 1.8rem;
+    font-weight: bold;
+  }
+}
+.dm-form_box {
+  margin-top: 10px;
+  margin-bottom: 50px;
+}
+.message_user_name a{
+  font-size: 14px;
+  font-weight: bold;
+  color: #333;
+}
+.message_time {
+  font-size: .8rem;
+}
+.message_box {
+
 }
 //フッター
 footer {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,6 +13,7 @@ class MessagesController < ApplicationController
   def destroy
     message = Message.find(params[:id])
     message.destroy
+    flash[:success] = "メッセージを削除しました"
     redirect_back(fallback_location: root_path)
   end
 

--- a/app/views/rooms/show.html.haml
+++ b/app/views/rooms/show.html.haml
@@ -1,10 +1,29 @@
-- @room.messages.each do |message|
-  = link_to user_path(message.user) do
-    = message.user.nickname
-    \:
-  = message.content
-  %br/
-= form_with model: @message, url: messages_path, local: true do |f|
-  = f.text_field :content, class: 'form-control'
-  = f.hidden_field :room_id, value: @room.id
-  = f.submit '送信', class: 'btn btn-info btn-block'
+.uk-container.uk-container-small.uk-container-center
+  .dm-room_title
+    %h2
+      メッセージルーム
+  .dm-form_box
+    .uk-card.uk-card-default.uk-card-body
+      %strong>= @another_entry.user.nickname
+      さんへメッセージを送る
+      = form_with model: @message, url: messages_path, local: true do |f|
+        = f.text_area :content, placeholder: "メッセージ内容を入力してください", class: 'uk-textarea', size: "94x10"
+        = f.hidden_field :room_id, value: @room.id
+        .uk-margin-top.uk-text-center
+          = f.submit '送信', class: 'uk-button uk-button-primary uk-border-rounded'
+  - @room.messages.all.reverse_order.each do |message|
+    .uk-margin
+      .uk-card.uk-card-default.uk-card-body.uk-card-small
+        .uk-flex.uk-flex-between
+          .message_user_infoBox
+            = image_tag '/assets/noimage.png', alt: 'プロフィール画像', size: '50x80', class: 'uk-border-circle'
+            %span.message_user_name
+              = link_to user_path(message.user) do
+                = message.user.nickname
+            = l message.created_at, format: :short,class: 'uk-text-muted uk-text-normal'
+          -if message.user_id == current_user.id
+            .edit_post_box
+              %span.fa-trash
+                = link_to '削除', message, method: :delete, data: { confirm: "本当に削除しますか？" }
+        .message_box
+          = safe_join(message.content.split("\n"),tag(:br))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       get  'done', to:    'items#done', as: 'done'
     end
   end
-  resources :messages, only: [:create]
+  resources :messages, only: [:create, :destroy]
   resources :rooms, only: [:show, :create]
   resources :stocks, only: %i(index create destroy)
   resources :account_activations, only: [:edit]


### PR DESCRIPTION

## やったこと
・DMの削除機能の追加
・DMページのデザイン
・メッセージを投稿時間（created_at)が新しいもの順から表示させるようにした( `@room.messages.all.reverse_order.each`)

## やらないこと
無し

## できるようになること（ユーザ目線）
DMの削除

## できなくなること（ユーザ目線）
投稿機能の編集

## 動作確認
ブラウザで確認、結果はOK

close #72 #73