### PR TITLE
[Add] 投稿一覧ページにページネーション機能を追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -224,6 +224,9 @@ body {
 .post_user_nickname a {
     color: #28b7c4;
 }
+.post_user_title {
+  font-size: 0.9rem;
+}
 .post_user_content_introduction {
   font-size: .75rem;
 }
@@ -233,6 +236,17 @@ body {
   color: #666!important;
   transition: opacity .2s;
 }
+//ページネーション
+ .uk-pagination>* {
+  padding-left: 0;
+ }
+ .uk-pagination>.uk-active.current {
+   border-radius: 50%;
+   background-color: #0366d6;
+   color: white;
+   font-weight: bolder;
+   padding: 0 6px;
+ }
 //投稿詳細ページ
 .edit_post_box {
    font-size: .8rem;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   require 'payjp'
 
   def index
-    @items = Item.all.order(created_at: :desc)
+    items = Item.all.order(created_at: :desc)
+    @items = Kaminari.paginate_array(items).page(params[:page]).per(10)
   end
 
   def new

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -45,3 +45,5 @@
               - if item.image.attached?
                 .uk-panel.uk-vertical-align
                   = image_tag item.image, alt: '投稿画像', size: '120x100',class: 'uk-vertical-align-middle'
+        -# 10件までページネーション
+        = paginate @items, theme: 'my_custom_theme'

--- a/app/views/kaminari/my_custom_theme/_first_page.html.haml
+++ b/app/views/kaminari/my_custom_theme/_first_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "First" page
+-#  available local variables
+-#    url:           url to the first page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%li.first
+  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote

--- a/app/views/kaminari/my_custom_theme/_gap.html.haml
+++ b/app/views/kaminari/my_custom_theme/_gap.html.haml
@@ -1,0 +1,8 @@
+-#  Non-link tag that stands for skipped pages...
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.page.gap.uk-margin-small-left
+  = t('views.pagination.truncate').html_safe

--- a/app/views/kaminari/my_custom_theme/_last_page.html.haml
+++ b/app/views/kaminari/my_custom_theme/_last_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Last" page
+-#  available local variables
+-#    url:           url to the last page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.last.uk-margin-small-left
+  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote

--- a/app/views/kaminari/my_custom_theme/_next_page.html.haml
+++ b/app/views/kaminari/my_custom_theme/_next_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Next" page
+-#  available local variables
+-#    url:           url to the next page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.next.uk-margin-small-left
+  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote

--- a/app/views/kaminari/my_custom_theme/_page.html.haml
+++ b/app/views/kaminari/my_custom_theme/_page.html.haml
@@ -1,0 +1,10 @@
+-#  Link showing page number
+-#  available local variables
+-#    page:          a page object for "this" page
+-#    url:           url to this page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span{class: "uk-margin-small-left uk-active#{' current' if page.current?}"}
+  = link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}

--- a/app/views/kaminari/my_custom_theme/_paginator.html.haml
+++ b/app/views/kaminari/my_custom_theme/_paginator.html.haml
@@ -1,0 +1,18 @@
+-#  The container tag
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-#    paginator:     the paginator that renders the pagination tags inside
+= paginator.render do
+  %ul.uk-pagination.uk-flex-center{"uk-margin" => ""}
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/my_custom_theme/_prev_page.html.haml
+++ b/app/views/kaminari/my_custom_theme/_prev_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Previous" page
+-#  available local variables
+-#    url:           url to the previous page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.prev.uk-margin-small-left
+  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,14 @@
+#created_atを〇月/〇日 〇時〇分で表示（日本時間）
 ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
       short: "%m/%d %H:%M"
+#ページネーションを日本語表記
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."


### PR DESCRIPTION
## やったこと
投稿一覧ページにページネーション機能を追加
　・デザインも制作
　・投稿は1ページにつき10件まで表示
　・ページの移動が英語表記（Next,Lastなど)日本語表記に変更

## やらないこと
なし

## できるようになること（ユーザ目線）
10件ごとにページを移動できるようになる。
## できなくなること（ユーザ目線）
なし
## 動作確認
ブラウザで確認、結果は良好
## 該当issue
close #61