### PR TITLE
Feature/search item index

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,11 @@ class ItemsController < ApplicationController
   # require 'payjp'
 
   def index
-    items = Item.all.order(created_at: :desc)
+    if params[:search].present?
+      items = Item.items_serach(params[:search])
+    else
+      items = Item.all.order(created_at: :desc)
+    end
     @items = Kaminari.paginate_array(items).page(params[:page]).per(10)
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,4 +25,9 @@ class Item < ApplicationRecord
   def stocked?(user)
     stock_users.include?(user)
   end
+
+  #検索メソッド、タイトルと内容をあいまい検索する
+  def self.items_serach(search)
+    Item.where(['title LIKE ? OR content LIKE ?', "%#{search}%", "%#{search}%"])
+  end
 end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -5,9 +5,9 @@
         .uk-card.uk-card-default.uk-card-body.uk-card-small
           %ul
             %li.search_friend
-              .uk-text-bold.uk-text-secondary
-                検索ワードで探す
-              .uk-input.uk-form-small
+              = form_with(url: items_path, method: :get , local: true) do |f|
+                = f.label :検索ワードで探す, class: 'uk-text-bold uk-text-secondary'
+                = f.text_field :search, placeholder: '投稿タイトル、本文で検索', class: 'uk-input uk-form-small'
             %li.search_friend_by_categorize
               .uk-text-secondary.uk-text-bold
                 カテゴリで探す


### PR DESCRIPTION
## やったこと
投稿一覧ページに投稿タイトルと本文を検索できる機能を追加
## やらないこと
なし
## できるようになること（ユーザ目線）
目的に応じた投稿を素早く見つけ津ことができるようになる。
## できなくなること（ユーザ目線）
なし
## 動作確認
ブラウザで確認、結果は良好
## 該当issue
close #87 
