### PR TITLE
[Fix]マイページのページネーションのバグを修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,10 +27,10 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     # ストック一覧を取得
     stock_items = Stock.get_stock_items(current_user)
-    @stock_items = Kaminari.paginate_array(stock_items).page(params[:page]).per(10)
+    @stock_items = Kaminari.paginate_array(stock_items).page(params[:stocks_page]).per(10)
     # 投稿した出品一覧を取得
     posted_items = @user.items
-    @posted_items = Kaminari.paginate_array(posted_items).page(params[:page]).per(10)
+    @posted_items = Kaminari.paginate_array(posted_items).page(params[:items_page]).per(10)
     # Entryモデルからログインユーザーのレコードを抽出
     @current_entry = Entry.where(user_id: current_user.id)
     # Entryモデルからメッセージ相手のレコードを抽出

--- a/app/views/items/_item_index.html.haml
+++ b/app/views/items/_item_index.html.haml
@@ -6,5 +6,5 @@
       %p.post_user_title
         = link_to item.title, item_path(item)
   /10件毎にページネーション
-.paginate
-  = paginate @posted_items
+.mypage_paginate
+  = paginate @posted_items, param_name: 'items_page', theme: 'my_custom_theme'

--- a/app/views/stocks/_stock.html.haml
+++ b/app/views/stocks/_stock.html.haml
@@ -6,5 +6,5 @@
       %p.post_user_title
         = link_to item.title, item_path(item)
   /10件毎にページネーション
-.paginate
-  = paginate @posted_items
+.mypage_paginate
+  = paginate @stock_items, param_name: 'stocks_page', theme: 'my_custom_theme'


### PR DESCRIPTION
## やったこと
マイページのページネーションのバグを修正

## やらないこと
ページネーション部分のデザイン、テスト
## できるようになること（ユーザ目線）
投稿履歴、お気に入り履歴をそれぞれ独立してページネーションできるようになる
## できなくなること（ユーザ目線）
なし
## 動作確認
ブラウザで確認、結果は良好
## 該当issue
close #98 
