### PR TITLE
fix:Twitter認証のテストが失敗するバグを修正

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   config.include LoginSupport # 作成したヘルパーを追加
+  config.include OmniauthMocks
+  config.include NotificationsHelper
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -1,9 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
-#include OmniauthMocks
 
 RSpec.describe 'Twitterログイン', type: :system do
-  pending 'OmniauthMocksモジュールをincludeするとテストに成功するが、他のシステムスペックのテストがすべて失敗してしまう'
-  xdescribe 'Twitterログイン処理' do
+  describe 'Twitterログイン処理' do
     before do
       visit login_path
       OmniAuth.config.test_mode = true
@@ -12,7 +12,7 @@ RSpec.describe 'Twitterログイン', type: :system do
 
     context '有効なユーザーだったとき' do
       it 'ユーザーはTwitter認証に成功すること' do
-        Rails.application.env_config['omniauth.auth'] = twitter_mock
+        twitter_mock
         click_on 'twitterアカウントでログイン'
         expect(page).to have_content('Twitterログインに成功しました。')
       end
@@ -20,7 +20,7 @@ RSpec.describe 'Twitterログイン', type: :system do
 
     context '無効なユーザーだったとき' do
       it 'ユーザーは認証に失敗すること' do
-        Rails.application.env_config['omniauth.auth'] = twitter_invalid_mock
+        twitter_invalid_mock
         click_on 'twitterアカウントでログイン'
         expect(page).to_not have_content('Twitterログインに成功しました。')
       end


### PR DESCRIPTION
## やったこと
Twitter認証のテストが失敗するバグを修正

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）

## できるようになること（ユーザ目線）

## 動作確認
テストを実行して確認、結果はOK

## 該当issue
無し
