### PR TITLE
twitter認証のテストがCIでのみ落ちるバグの修正

### DIFF
--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -9,19 +9,24 @@ RSpec.describe 'Twitterログイン', type: :system do
       OmniAuth.config.test_mode = true
     end
 
+    after do
+      Rails.application.env_config['omniauth.auth'] = nil
+    end
+
     context '有効なユーザーだったとき' do
       it 'ユーザーはTwitter認証に成功すること' do
-        twitter_mock
+        Rails.application.env_config['omniauth.auth'] = twitter_mock
         click_on 'twitterアカウントでログイン'
-        expect(page).to have_content('Twitterログインに成功しました。')
+        expect(page).to have_css '.uk-alert-success'
+        expect(page).to have_content 'Twitterログインに成功しました。'
       end
     end
 
     context '無効なユーザーだったとき' do
       it 'ユーザーは認証に失敗すること' do
-        twitter_invalid_mock
+        Rails.application.env_config['omniauth.auth'] = twitter_invalid_mock
         click_on 'twitterアカウントでログイン'
-        expect(page).to_not have_content('Twitterログインに成功しました。')
+        expect(page).to_not have_content 'Twitterログインに成功しました。'
       end
     end
   end


### PR DESCRIPTION
## やったこと
twitter認証のテストがCIでのみ落ちるバグの修正
## 動作確認
pushしてCIビルドして確認、結果は×
テストが失敗する

## 該当issue
無し
