### PR TITLE
アカウント有効化メール送信処理のテストを追加した

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -2,11 +2,11 @@
 
 RSpec.describe UserMailer, type: :mailer do
   let(:user) { FactoryBot.create(:user, email: 'mailer_tester@example.com') }
+   # Base64 でエンコードされたものをデコードして比較できるようにする
+  let(:mail_body) { mail.body.encoded.split(/\r\n/).map { |i| Base64.decode64(i) }.join }
 
   describe 'パスワードリセット処理' do
     let(:mail) { UserMailer.password_reset(user) }
-    # Base64 encodeをデコードして比較できるようにする
-    let(:mail_body) { mail.body.encoded.split(/\r\n/).map { |i| Base64.decode64(i) }.join }
 
     it 'ヘッダーが正しく表示されること' do
       user.reset_token = User.new_token
@@ -19,6 +19,25 @@ RSpec.describe UserMailer, type: :mailer do
     it 'メール文が正しく表示されること' do
       user.reset_token = User.new_token
       expect(mail_body).to match user.reset_token
+      expect(mail_body).to match CGI.escape(user.email)
+    end
+  end
+
+  describe 'アカウント有効化メール送信処理' do
+    let(:mail) { UserMailer.account_activation(user) }
+    # Base64 encodeをデコードして比較できるようにする
+
+    it 'ヘッダーが正しく表示されること' do
+      user.activation_token = User.new_token
+      expect(mail.to).to eq ['mailer_tester@example.com']
+      expect(mail.from).to eq ['miraishida00510@gmail.com']
+      expect(mail.subject).to eq 'アカウントの有効化をお願いします。'
+    end
+
+    # メールプレビューのテスト
+    it 'メール文が正しく表示されること' do
+      user.activation_token = User.new_token
+      expect(mail_body).to match user.activation_token
       expect(mail_body).to match CGI.escape(user.email)
     end
   end


### PR DESCRIPTION
## やったこと
アカウント有効化メール送信処理のテストを追加した

## やらないこと
無し
## できるようになること（ユーザ目線）
無し
## できなくなること（ユーザ目線）
無し
## 動作確認
テストを実行して確認、結果はOK
## 該当issue
無し
