### PR TITLE
safe_joinメソッドを使い、改行がそのまま反映されるように変更した

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -49,7 +49,7 @@
       .user_nickname.uk-margin
         = link_to @item.user.nickname, user_path(@item.user_id), class: 'uk-text-normal uk-text-bold'
       .post_user_introduction_info.uk-margin
-        = @item.user.introduction
+        = safe_join(@item.user.introduction.split("\n"),tag(:br)) unless @item.user.introduction.nil?
       .uk-margin
         - if logged_in?
           - unless @item.user_id == current_user.id

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -27,7 +27,7 @@
         - if logged_in? && @user.id == current_user.id
           = link_to 'プロフィールの編集', edit_user_path(current_user)
       %p
-        = @user.introduction
+        = safe_join(@user.introduction.split("\n"),tag(:br)) unless @user.introduction.nil?
     .uk-card.uk-card-small.uk-card-default.uk-card-body.uk-margin-bottom.profole_box
       %h2.mypage_content_title.fa-history
         投稿履歴


### PR DESCRIPTION
## やったこと
safe_joinメソッドを使い、自己紹介文の改行がそのまま反映されるように変更した

## やらないこと
無し

## できるようになること（ユーザ目線）
改行をそのままマイページに反映出来るようになる

## できなくなること（ユーザ目線）
無し

## 動作確認
ブラウザで確認、結果はOK
## 該当issue
close #160 
